### PR TITLE
feat: Remove panic, prefer error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use unic_langid::LanguageIdentifier;
+
 /// Errors that can occur when loading or parsing fluent resources.
 #[derive(Debug, thiserror::Error)]
 pub enum LoaderError {
@@ -53,3 +55,19 @@ impl fmt::Display for FluentError {
 }
 
 impl std::error::Error for FluentError {}
+
+/// An error that happened while looking up messages
+#[derive(Debug, thiserror::Error)]
+pub enum LookupError {
+    #[error("Couldn't retrieve message with ID `{0}`")]
+    MessageRetrieval(String),
+    #[error("Couldn't find attribute `{attribute}` for message-id `{message_id}`")]
+    AttributeNotFound {
+        message_id: String,
+        attribute: String,
+    },
+    #[error("Language ID `{0}` has not been loaded")]
+    LangNotLoaded(LanguageIdentifier),
+    #[error("Fluent error: {0}")]
+    FluentError(FluentError),
+}

--- a/src/loader/arc_loader.rs
+++ b/src/loader/arc_loader.rs
@@ -7,7 +7,7 @@ use crate::languages::negotiate_languages;
 use crate::FluentBundle;
 use fluent_bundle::{FluentResource, FluentValue};
 
-use crate::error::LoaderError;
+use crate::error::{LoaderError, LookupError};
 
 pub use unic_langid::LanguageIdentifier;
 
@@ -114,12 +114,12 @@ impl super::Loader for ArcLoader {
         args: Option<&HashMap<T, FluentValue>>,
     ) -> String {
         for lang in negotiate_languages(&[lang], &self.bundles.keys().collect::<Vec<_>>(), None) {
-            if let Some(val) = self.lookup_single_language(lang, text_id, args) {
+            if let Ok(val) = self.lookup_single_language(lang, text_id, args) {
                 return val;
             }
         }
         if *lang != self.fallback {
-            if let Some(val) = self.lookup_single_language(&self.fallback, text_id, args) {
+            if let Ok(val) = self.lookup_single_language(&self.fallback, text_id, args) {
                 return val;
             }
         }
@@ -134,12 +134,12 @@ impl super::Loader for ArcLoader {
         args: Option<&HashMap<T, FluentValue>>,
     ) -> Option<String> {
         for lang in negotiate_languages(&[lang], &self.bundles.keys().collect::<Vec<_>>(), None) {
-            if let Some(val) = self.lookup_single_language(lang, text_id, args) {
+            if let Ok(val) = self.lookup_single_language(lang, text_id, args) {
                 return Some(val);
             }
         }
         if *lang != self.fallback {
-            if let Some(val) = self.lookup_single_language(&self.fallback, text_id, args) {
+            if let Ok(val) = self.lookup_single_language(&self.fallback, text_id, args) {
                 return Some(val);
             }
         }
@@ -171,7 +171,7 @@ impl ArcLoader {
         lang: &LanguageIdentifier,
         text_id: &str,
         args: Option<&HashMap<T, FluentValue>>,
-    ) -> Option<String> {
+    ) -> Result<String, LookupError> {
         super::shared::lookup_single_language(&self.bundles, lang, text_id, args)
     }
 

--- a/src/loader/shared.rs
+++ b/src/loader/shared.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
 
-use crate::FluentBundle;
+use crate::{error::LookupError, FluentBundle};
 use fluent_bundle::{FluentResource, FluentValue};
 
 pub use unic_langid::LanguageIdentifier;
@@ -11,24 +11,36 @@ pub fn lookup_single_language<T: AsRef<str>, R: Borrow<FluentResource>>(
     lang: &LanguageIdentifier,
     text_id: &str,
     args: Option<&HashMap<T, FluentValue>>,
-) -> Option<String> {
-    let bundle = bundles.get(lang)?;
+) -> Result<String, LookupError> {
+    let bundle = bundles.get(lang)
+        .ok_or_else(|| LookupError::LangNotLoaded(lang.clone()))?;
+
     let mut errors = Vec::new();
+    let message_retrieve_error = || LookupError::MessageRetrieval(text_id.to_owned());
+
     let pattern = if let Some((msg, attr)) = text_id.split_once('.') {
         bundle
-            .get_message(msg)?
+            .get_message(msg)
+            .ok_or_else(message_retrieve_error)?
             .attributes()
-            .find(|attribute| attribute.id() == attr)?
+            .find(|attribute| attribute.id() == attr)
+            .ok_or_else(|| LookupError::AttributeNotFound {
+                message_id: msg.to_owned(),
+                attribute: attr.to_owned(),
+            })?
             .value()
     } else {
-        bundle.get_message(text_id)?.value()?
+        bundle.get_message(text_id)
+            .ok_or_else(message_retrieve_error)?
+            .value()
+            .ok_or_else(message_retrieve_error)?
     };
 
     let args = args.map(super::map_to_fluent_args);
     let value = bundle.format_pattern(pattern, args.as_ref(), &mut errors);
 
     if errors.is_empty() {
-        Some(value.into())
+        Ok(value.into())
     } else {
         panic!("Failed to format a message for locale {lang} and id {text_id}.\nErrors\n{errors:?}")
     }
@@ -43,7 +55,7 @@ pub fn lookup_no_default_fallback<S: AsRef<str>, R: Borrow<FluentResource>>(
 ) -> Option<String> {
     let fallbacks = fallbacks.get(lang)?;
     for l in fallbacks {
-        if let Some(val) = lookup_single_language(bundles, l, text_id, args) {
+        if let Ok(val) = lookup_single_language(bundles, l, text_id, args) {
             return Some(val);
         }
     }

--- a/src/loader/static_loader.rs
+++ b/src/loader/static_loader.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{languages::negotiate_languages, FluentBundle};
+use crate::{error::LookupError, languages::negotiate_languages, FluentBundle};
 use fluent_bundle::{FluentResource, FluentValue};
 
 pub use unic_langid::LanguageIdentifier;
@@ -39,7 +39,7 @@ impl StaticLoader {
         lang: &LanguageIdentifier,
         text_id: &str,
         args: Option<&HashMap<S, FluentValue>>,
-    ) -> Option<String> {
+    ) -> Result<String, LookupError> {
         super::shared::lookup_single_language(self.bundles, lang, text_id, args)
     }
 
@@ -64,13 +64,13 @@ impl super::Loader for StaticLoader {
         args: Option<&HashMap<T, FluentValue>>,
     ) -> String {
         for lang in negotiate_languages(&[lang], &self.bundles.keys().collect::<Vec<_>>(), None) {
-            if let Some(val) = self.lookup_single_language(lang, text_id, args) {
+            if let Ok(val) = self.lookup_single_language(lang, text_id, args) {
                 return val;
             }
         }
 
         if *lang != self.fallback {
-            if let Some(val) = self.lookup_single_language(&self.fallback, text_id, args) {
+            if let Ok(val) = self.lookup_single_language(&self.fallback, text_id, args) {
                 return val;
             }
         }
@@ -85,13 +85,13 @@ impl super::Loader for StaticLoader {
         args: Option<&HashMap<T, FluentValue>>,
     ) -> Option<String> {
         for lang in negotiate_languages(&[lang], &self.bundles.keys().collect::<Vec<_>>(), None) {
-            if let Some(val) = self.lookup_single_language(lang, text_id, args) {
+            if let Ok(val) = self.lookup_single_language(lang, text_id, args) {
                 return Some(val);
             }
         }
 
         if *lang != self.fallback {
-            if let Some(val) = self.lookup_single_language(&self.fallback, text_id, args) {
+            if let Ok(val) = self.lookup_single_language(&self.fallback, text_id, args) {
                 return Some(val);
             }
         }


### PR DESCRIPTION
Resolves #54

This PR swaps the panic call for proper error handling. The function now returns a `Result` with a specialized error type, rather than an `Option`.

Tests for these new errors are still TODO; I just wanted to collect some feedback on this first.